### PR TITLE
Add initial migrations and Eloquent models for core entities

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -22,6 +22,15 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 
+# Cài đặt Yarn
+RUN npm install -g yarn
+
+# Cài đặt wp-cli
+
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+RUN chmod +x wp-cli.phar
+RUN mv wp-cli.phar /usr/local/bin/wp
+
 # Cài đặt Composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
        && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \

--- a/wordpress/themes/alex-interview/app/Models/BaseModel.php
+++ b/wordpress/themes/alex-interview/app/Models/BaseModel.php
@@ -1,0 +1,9 @@
+<?php
+// app/Models/BaseModel.php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseModel extends Model {
+      // Add your custom methods here
+}

--- a/wordpress/themes/alex-interview/app/Models/Competition.php
+++ b/wordpress/themes/alex-interview/app/Models/Competition.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Competition extends BaseModel
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'name',
+        'logo'
+    ];
+
+    public function teams()
+    {
+        return $this->hasMany(Team::class);
+    }
+
+    public function Matcheses()
+    {
+        return $this->hasMany(Matches::class);
+    }
+}

--- a/wordpress/themes/alex-interview/app/Models/Country.php
+++ b/wordpress/themes/alex-interview/app/Models/Country.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Country extends BaseModel
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'name',
+        'logo'
+    ];
+
+    public function teams()
+    {
+        return $this->hasMany(Team::class);
+    }
+}

--- a/wordpress/themes/alex-interview/app/Models/Matches.php
+++ b/wordpress/themes/alex-interview/app/Models/Matches.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Matches extends BaseModel
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'competition_id',
+        'home_team_id',
+        'away_team_id',
+        'status_id',
+        'match_time',
+        'home_scores',
+        'away_scores'
+    ];
+
+    protected $casts = [
+        'home_scores' => 'array',
+        'away_scores' => 'array'
+    ];
+
+    public function competition()
+    {
+        return $this->belongsTo(Competition::class);
+    }
+
+    public function homeTeam()
+    {
+        return $this->belongsTo(Team::class, 'home_team_id');
+    }
+
+    public function awayTeam()
+    {
+        return $this->belongsTo(Team::class, 'away_team_id');
+    }
+}

--- a/wordpress/themes/alex-interview/app/Models/Team.php
+++ b/wordpress/themes/alex-interview/app/Models/Team.php
@@ -1,0 +1,39 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Team extends \App\Models\BaseModel
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'competition_id',
+        'country_id',
+        'name',
+        'logo'
+    ];
+
+    public function competition()
+    {
+        return $this->belongsTo(Competition::class);
+    }
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class);
+    }
+
+    public function homeMatcheses()
+    {
+        return $this->hasMany(Matches::class, 'home_team_id');
+    }
+
+    public function awayMatcheses()
+    {
+        return $this->hasMany(Matches::class, 'away_team_id');
+    }
+}

--- a/wordpress/themes/alex-interview/database/migrations/2025_01_09_171326_create_countries_table.php
+++ b/wordpress/themes/alex-interview/database/migrations/2025_01_09_171326_create_countries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('countries', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('countries');
+    }
+};

--- a/wordpress/themes/alex-interview/database/migrations/2025_01_09_171421_create_competitions_table.php
+++ b/wordpress/themes/alex-interview/database/migrations/2025_01_09_171421_create_competitions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('competitions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('competitions');
+    }
+};

--- a/wordpress/themes/alex-interview/database/migrations/2025_01_09_171433_create_teams_table.php
+++ b/wordpress/themes/alex-interview/database/migrations/2025_01_09_171433_create_teams_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/wordpress/themes/alex-interview/database/migrations/2025_01_09_171442_create_matches_table.php
+++ b/wordpress/themes/alex-interview/database/migrations/2025_01_09_171442_create_matches_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('matches', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('matches');
+    }
+};


### PR DESCRIPTION
Included migrations for `countries`, `competitions`, `teams`, and `matches` tables, along with their respective Eloquent models. Introduced a `BaseModel` for shared functionality, and enhanced the Dockerfile to install Yarn and WP-CLI.